### PR TITLE
Install `wheel` to be used by `pip`

### DIFF
--- a/base.Makefile
+++ b/base.Makefile
@@ -186,7 +186,8 @@ install-python-ven%: ## install-python-venv: Create Python virtual environment
 	$(LOG)
 	test -d "$(VENV)" || $(PYTHON) -m venv "$(VENV)"
 	# `venv` could install outdated `pip` and `setuptools` versions
-	$(PIP) install --upgrade pip setuptools
+	# Install `wheel` too (used by `pip` if available when installing packages)
+	$(PIP) install --upgrade pip setuptools wheel
 	$(PIP) install pip-tools
 
 install-node-pro%: ## install-node-prod: Install node dependencies for production


### PR DESCRIPTION
Fix warning `Could not build wheels for xxxx since package 'wheel' is not
installed.`

See: https://github.com/pypa/pip/issues/8102