### PR TITLE
Use docker Compose V2 by default now

### DIFF
--- a/base.Makefile
+++ b/base.Makefile
@@ -437,7 +437,7 @@ endif
 endif
 
 DOCKER ?= docker
-DOCKER_COMPOSE ?= docker-compose
+DOCKER_COMPOSE ?= docker compose
 
 DEFAULT_APP_CONTAINER ?= app
 DEFAULT_CI_CONTAINER ?= ci


### PR DESCRIPTION
> From July 2023 Compose V1 stopped receiving updates.
> It’s also no longer available in new releases of Docker Desktop.

https://docs.docker.com/compose/migrate/