### PR TITLE
Recursively lint all .jinja2 files in templates

### DIFF
--- a/base.Makefile
+++ b/base.Makefile
@@ -325,8 +325,7 @@ clea%: least-specific-clean ## clean: Clean all built assets
 lint-pytho%: ## lint-python: Lint python source
 	$(LOG)
 	$(RUFF) check $(LINTED_PYTHON_DIRS)
-	$(DJLINT) $(TEMPLATE_DIRS) --lint
-	$(DJLINT) $(TEMPLATE_DIRS) --check
+	find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | xargs $(DJLINT) --check --lint
 
 lint-nod%: ## lint-node: Lint node source
 	$(LOG)


### PR DESCRIPTION
This change updates the lint-python target to recursively find and lint all `.jinja2` files within the `$(TEMPLATE_DIRS)` directory.

close #11