### PR TITLE
Fix 18 python v5

### DIFF
--- a/base.Makefile
+++ b/base.Makefile
@@ -340,8 +340,9 @@ ifdef _PYTHON
 	$(MAKE) lint-python
 endif
 
-fix-pytho%: ## fix-python: Fix python source format
+fix-pytho%: ## fix-python: Fix python source format and lint violations
 	$(LOG)
+	$(RUFF) check --fix $(LINTED_PYTHON_DIRS)
 	$(RUFF) format $(LINTED_PYTHON_DIRS)
 	find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | xargs $(DJLINT) --reformat
 


### PR DESCRIPTION
In this PR, the possibility of fixing trivial lint violations has been added to fix-python so that it be consistent with errors reported by lint-python target. ( This PR is for version v5 of MakeCitron ) 

close #18 

