### PR TITLE
v3 - Add formatting checks to Python linting process

### DIFF
--- a/base.Makefile
+++ b/base.Makefile
@@ -46,6 +46,7 @@ TEMPLATE_DIRS ?= $(PYTHON_SRCDIR)/templates
 PYTHON_PKG_TOOLS ?= pip pip-tools setuptools wheel
 ### Commands (from `PYTHON_BINDIR` via `PATH` environment variable)
 DJLINT ?= djlint
+DJLINT_JINJA_CMD = find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | xargs --no-run-if-empty $(DJLINT)
 FLASK ?= flask
 PIP ?= pip
 PIP_COMPILE ?= pip-compile --generate-hashes
@@ -327,9 +328,8 @@ lint-pytho%: ## lint-python: Lint python source
 	$(RUFF) check $(LINTED_PYTHON_DIRS)
 	$(RUFF) format --diff $(LINTED_PYTHON_DIRS)
 	@if [ -d $(TEMPLATE_DIRS) ]; then \
-		echo "Linting Jinja2 templates in $(TEMPLATE_DIRS)"; \
-		find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | \
-		xargs --no-run-if-empty $(DJLINT) --check --lint; \
+		echo "$(DJLINT_JINJA_CMD) --check --lint"; \
+		$(DJLINT_JINJA_CMD) --check --lint; \
 	fi
 
 lint-nod%: ## lint-node: Lint node source
@@ -350,9 +350,8 @@ fix-pytho%: ## fix-python: Fix python source format and lint violations
 	$(RUFF) check --fix $(LINTED_PYTHON_DIRS)
 	$(RUFF) format $(LINTED_PYTHON_DIRS)
 	@if [ -d $(TEMPLATE_DIRS) ]; then \
-		echo "Fixing Jinja2 templates in $(TEMPLATE_DIRS)"; \
-		find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | \
-		xargs --no-run-if-empty $(DJLINT) --reformat; \
+		echo "$(DJLINT_JINJA_CMD) --reformat"; \
+		$(DJLINT_JINJA_CMD) --reformat; \
 	fi
 
 fix-nod%: ## fix-node: Fix node source format

--- a/base.Makefile
+++ b/base.Makefile
@@ -326,7 +326,11 @@ lint-pytho%: ## lint-python: Lint python source
 	$(LOG)
 	$(RUFF) check $(LINTED_PYTHON_DIRS)
 	$(RUFF) format --diff $(LINTED_PYTHON_DIRS)
-	find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | xargs $(DJLINT) --check --lint
+	@if [ -d $(TEMPLATE_DIRS) ]; then \
+		echo "Linting Jinja2 templates in $(TEMPLATE_DIRS)"; \
+		find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | \
+		xargs --no-run-if-empty $(DJLINT) --check --lint; \
+	fi
 
 lint-nod%: ## lint-node: Lint node source
 	$(LOG)
@@ -345,7 +349,11 @@ fix-pytho%: ## fix-python: Fix python source format and lint violations
 	$(LOG)
 	$(RUFF) check --fix $(LINTED_PYTHON_DIRS)
 	$(RUFF) format $(LINTED_PYTHON_DIRS)
-	find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | xargs $(DJLINT) --reformat
+	@if [ -d $(TEMPLATE_DIRS) ]; then \
+		echo "Fixing Jinja2 templates in $(TEMPLATE_DIRS)"; \
+		find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | \
+		xargs --no-run-if-empty $(DJLINT) --reformat; \
+	fi
 
 fix-nod%: ## fix-node: Fix node source format
 	$(LOG)

--- a/base.Makefile
+++ b/base.Makefile
@@ -46,7 +46,7 @@ TEMPLATE_DIRS ?= $(PYTHON_SRCDIR)/templates
 PYTHON_PKG_TOOLS ?= pip pip-tools setuptools wheel
 ### Commands (from `PYTHON_BINDIR` via `PATH` environment variable)
 DJLINT ?= djlint
-DJLINT_JINJA_CMD = find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | xargs --no-run-if-empty $(DJLINT)
+DJLINT_JINJA_CMD := find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | xargs --no-run-if-empty $(DJLINT)
 FLASK ?= flask
 PIP ?= pip
 PIP_COMPILE ?= pip-compile --generate-hashes

--- a/base.Makefile
+++ b/base.Makefile
@@ -325,6 +325,7 @@ clea%: least-specific-clean ## clean: Clean all built assets
 lint-pytho%: ## lint-python: Lint python source
 	$(LOG)
 	$(RUFF) check $(LINTED_PYTHON_DIRS)
+	$(RUFF) format --diff $(LINTED_PYTHON_DIRS)
 	find $(TEMPLATE_DIRS) -type f -name '*.jinja2' | xargs $(DJLINT) --check --lint
 
 lint-nod%: ## lint-node: Lint node source


### PR DESCRIPTION
Ensure `make lint-python` also checks code formatting, not just lint rules. This helps maintain consistent style across files and avoids formatting discrepancies.

Resolves: #23